### PR TITLE
Changed formula and data conversion method in retrieved data

### DIFF
--- a/growatt-inverter.php
+++ b/growatt-inverter.php
@@ -129,13 +129,10 @@ function retrieve_growatt_data($command)
 		if ($continue) {
 
 			$data = json_decode($result, JSON_PRETTY_PRINT);
-			$nowpower = $data['powerValue'];
-			$todaypower = $data['todayStr'];
-
-			$nowpower=filter_var($nowpower,FILTER_SANITIZE_NUMBER_INT)/10;
-			$todaypower=filter_var($todaypower,FILTER_SANITIZE_NUMBER_INT);
+			$nowpower = (float)str_ireplace('kWh', '', $data['powerValue']);
+			$todaypower = (float)str_ireplace('kWh', '', $data['todayStr']);
 			
-			$str=( $nowpower.';'. $todaypower*100 );			
+			$str=( $nowpower.';'. $todaypower * 1000 );	#times 1000 to convert the 0.1kWh to 100 WattHour and to convert 2.1kWh to 2100 WattHour
 			lg('Growatt Inverter: '. $nowpower.' for domoticz: '.$str);
 			ud(DOMOTICZDEVICE,0,$str,'GrowattInverter: Generation updated');
 		}


### PR DESCRIPTION
When using the original method, I noticed that when the delivery was 1kWh, 2kWh, 3kWh, 4kWh, domoticz would show it as 0.1, 0.2, 0.3, 0.4. This was due to it expecting 2 numbers but not always getting 2 numbers when the deliverd today is a round number, see json below:
{
  "plantNumber": 1,
  "treeValue": "5066.6",
  "treeStr": "5066.6",
  "nominalPowerStr": "2kW",
  "eventMessBeanList": [],
  "yearValue": "0.0",
  "formulaCo2Vlue": "91.6",
  "formulaCo2Str": "91.6kg",
  "todayValue": "6.0",
  "totalStr": "91.6kWh",
  "powerValue": "912.4",
  "totalValue": "91.6",
  "nominalPowerValue": "2000.0",
  "monthValue": "91.6",
  "todayStr": "6kWh",
  "monthStr": "91.6kWh",
  "formulaCoalStr": "36.6kg",
  "alarmValue": 0,
  "yearStr": "0kWh",
  "formulaCoalValue": "36.6"
}

the other option was to get the field todayValue. however I still think this solution is nicer than using var filters.